### PR TITLE
在v2ray相关协议的dns配置中，增加"skipFallback": true参数

### DIFF
--- a/docs/01.指南/01.指南/02.个人使用.md
+++ b/docs/01.指南/01.指南/02.个人使用.md
@@ -155,7 +155,8 @@ echo -e "nameserver 8.8.8.8" > /etc/resolv.conf
         "port": 53,
         "domains": [
            "geosite:netflix"
-        ]
+        ],
+        "skipFallback": true
       }
     ]
   }
@@ -252,7 +253,8 @@ Xray
         "port": 53,
         "domains": [
            "geosite:netflix" ,"geosite:disney"
-        ]
+        ],
+        "skipFallback": true
       }
     ]
   }
@@ -338,7 +340,8 @@ bash <(curl -Ls https://raw.githubusercontent.com/vaxilu/x-ui/master/install.sh)
         "port": 53,
         "domains": [
            "geosite:netflix"
-        ]
+        ],
+        "skipFallback": true
       }
     ]
   },

--- a/docs/01.指南/01.指南/03.团队使用.md
+++ b/docs/01.指南/01.指南/03.团队使用.md
@@ -36,7 +36,8 @@ vi /etc/XrayR/dns.json
     {
       "address": "4.4.4.4（以实际为准）",
       "port": 53,
-      "domains": ["geosite:netflix"]
+      "domains": ["geosite:netflix"],
+      "skipFallback": true
     }
   ],
   "tag": "dns_inbound"

--- a/docs/01.指南/01.指南/07.解锁域名收集.md
+++ b/docs/01.指南/01.指南/07.解锁域名收集.md
@@ -12,7 +12,8 @@
         "port": 53,
         "domains": [
            "geosite:netflix","geosite:disney","gamer.com.tw","bahamut.com.tw","hinet.net","fbcdn.net","gvt1.com","digicert.com","viblast.com"
-        ]
+        ],
+        "skipFallback": true
       }
     ]
   }
@@ -32,7 +33,8 @@
         "port": 53,
         "domains": [
            "geosite:netflix","geosite:disney","geosite:bahamut"
-        ]
+        ],
+        "skipFallback": true
       }
     ]
   }


### PR DESCRIPTION
在v2ray相关协议的dns配置中（仅测试xray），增加"skipFallback": true参数。

解决：对于未匹配domains的域名，不使用nfdns提供的解锁dns进行解析，增加解析速度或者在nfdns过期后不产生大规模解析错误。